### PR TITLE
【Fixed】Feature/issues 64

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -64,7 +64,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(_team_id)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -27,7 +27,9 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
+    if !(assign.team.owner == current_user || assigned_user == current_user)
+      I18n.t('views.messages.cannot_delete_only_owner_or_self')
+    elsif assigned_user == assign.team.owner
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :user_check, only: %i[edit]
 
   def index
     @teams = Team.all
@@ -51,6 +52,10 @@ class TeamsController < ApplicationController
 
   def set_team
     @team = Team.friendly.find(params[:id])
+  end
+
+  def user_check
+    redirect_to @team, notice: I18n.t('views.messages.cannot_edit_only_owner') unless @team.owner == current_user
   end
 
   def team_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,8 @@ en:
       cannot_delete_the_leader: 'The leader cannot be deleted'
       does_not_exist_email: 'Email does not exist. Please make an account'
       cannot_delete_only_a_member: 'This user is only a member of this team and cannot be deleted'
+      cannot_delete_only_owner_or_self: 'This user is not owner or self and cannot be deleted'
+      cannot_edit_only_owner: 'This user is not owner and cannot be edited'
       delete_member: 'The member has been deleted'
       cannot_delete_member_4_some_reason: 'The file could not be deleted for some reason.'
       failed_to_post: 'Failed to post ...'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -214,6 +214,8 @@ ja:
       does_not_exist_email: 'メールアドレスが存在しません。アカウントを作成してください。'
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
+      cannot_delete_only_owner_or_self: 'このユーザーはオーナまたはユーザ自身でないため、削除できません。'
+      cannot_edit_only_owner: 'このユーザーはオーナでないため、編集できません。'
       delete_member: 'メンバーを削除しました。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'


### PR DESCRIPTION
以下のissueを実装した。
「チーム情報の操作に関しての機能を整えること」
・Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
・TeamのeditはTeamのリーダー（オーナー）のみができるようにすること